### PR TITLE
Connection status and additional device controls

### DIFF
--- a/src/components/serial/footer-btn.vue
+++ b/src/components/serial/footer-btn.vue
@@ -1,43 +1,70 @@
 <template>
-  <v-menu top v-model="menu" offset-y>
-    <!-- eslint-disable-next-line vue/no-unused-vars -->
-    <template #activator="{ on }">
-      <v-btn text dense small @click="activate(on)" v-if="currentDevice">
-        Serial: {{deviceName}}
-      </v-btn>
-      <v-btn text dense small @click="activate" v-else>Select Device Port</v-btn>
-    </template>
-    <v-list dense :style="{ padding: '0' }">
-      <v-list-item
-        v-for="device in devices"
-        :key="device.value"
-        @click="$serial.setCurrentDevice(device.value)"
-      >
-        <v-list-item-title>{{device.name}}</v-list-item-title>
-      </v-list-item>
-      <v-divider v-if="devices.length" />
-      <v-list-item
-        v-if="$serial.requestRequired"
-        @click="$serial.requestDevice()"
-      >
-        <v-list-item-title>
-          <v-icon left>mdi-plus</v-icon>
-          Add New Device
-        </v-list-item-title>
-      </v-list-item>
-    </v-list>
-  </v-menu>
+  <div>
+    <v-menu top v-model="menu" offset-y>
+      <!-- eslint-disable-next-line vue/no-unused-vars -->
+      <template #activator="{ on }">
+        <v-btn text dense small @click="activate(on)" v-if="currentDevice">
+          Serial: {{deviceName}}
+        </v-btn>
+        <v-btn text dense small @click="activate" v-else>Select Device Port</v-btn>
+      </template>
+      <v-list dense :style="{ padding: '0' }">
+        <v-list-item
+          v-for="device in devices"
+          :key="device.value"
+          @click="$serial.setCurrentDevice(device.value)"
+        >
+          <v-list-item-title>{{device.name}}</v-list-item-title>
+        </v-list-item>
+        <v-divider v-if="devices.length" />
+        <v-list-item
+          v-if="$serial.requestRequired"
+          @click="$serial.requestDevice()"
+        >
+          <v-list-item-title>
+            <v-icon left>mdi-plus</v-icon>
+            Add New Device
+          </v-list-item-title>
+        </v-list-item>
+        <v-list-item
+          v-if="$serial.currentDevice"
+          @click="$serial.reconnect()"
+        >
+          <v-list-item-title>
+            <v-icon left>mdi-refresh</v-icon>
+            Reconnect
+          </v-list-item-title>
+        </v-list-item>
+        <v-list-item
+          v-if="$serial.currentDevice"
+          @click="$serial.clearCurrentDevice()"
+        >
+          <v-list-item-title>
+            <v-icon left>mdi-close</v-icon>
+            Reset
+          </v-list-item-title>
+        </v-list-item>
+      </v-list>
+    </v-menu>
+    <status-bubble v-if="currentDevice" :status="status"/>
+  </div>
 </template>
 
 <script>
+import StatusBubble from './status-bubble.vue';
 
 export default {
+  components: {
+    StatusBubble,
+  },
   data() {
     return {
       menu: false,
       devices: [],
       currentDevice: (this.$serial && this.$serial.currentDevice) || null,
+      status: this.$serial && this.$serial.status,
       deviceCB: null,
+      statusCB: null,
     };
   },
   computed: {
@@ -55,11 +82,15 @@ export default {
   },
   mounted() {
     this.currentDevice = this.$serial.currentDevice || null;
+    this.status = this.$serial.status;
     this.deviceCB = (value) => { this.currentDevice = value; };
+    this.statusCB = (value) => { this.status = value; };
     this.$serial.on('currentDevice', this.deviceCB);
+    this.$serial.on('status', this.statusCB);
   },
   beforeDestroy() {
     if (this.deviceCB) this.$serial.off('currentDevice', this.deviceCB);
+    if (this.statusCB) this.$serial.off('status', this.statusCB);
   },
   methods: {
     activate() {

--- a/src/components/serial/status-bubble.vue
+++ b/src/components/serial/status-bubble.vue
@@ -1,0 +1,26 @@
+<template>
+  <v-chip class="mx-1" small label :color="color">{{statusText}}</v-chip>
+</template>
+
+<script>
+export default {
+  props: ['status'],
+  computed: {
+    color() {
+      switch (this.status) {
+        case 'connected': return 'success';
+        case 'connecting': return 'warning';
+        default: return 'error';
+      }
+    },
+    statusText() {
+      switch (this.status) {
+        case 'connected': return 'Connected';
+        case 'connecting': return 'Connecting';
+        case 'disconnected': return 'Disconnected';
+        default: return 'Unknown';
+      }
+    },
+  },
+};
+</script>

--- a/src/plugins/serial/websocket.js
+++ b/src/plugins/serial/websocket.js
@@ -49,6 +49,7 @@ class WebSocketAsync {
   }
 
   async connect() {
+    console.log('connect');
     return new Promise((resolve, reject) => {
       const socket = new WebSocket(this._url, this._protocols);
       socket.binaryType = 'arraybuffer';
@@ -63,6 +64,7 @@ class WebSocketAsync {
       };
 
       socket.onerror = (event) => {
+        console.log('caught error', event);
         reject(event);
       };
     });
@@ -156,18 +158,27 @@ class WebSocketSerial extends BaseSerial {
     }
 
     if (this.connected) {
+      console.log('disconnect device');
       this.disconnect();
     }
 
     this._currentSocket = this._getSocket(value);
     if (this._currentSocket) {
+      console.log('got a socket');
       Vue.set(this, 'currentDevice', value);
       this.emit('currentDevice', value);
       await this.connect();
     } else {
+      console.log('no socket');
       Vue.set(this, 'currentDevice', null);
       this.emit('currentDevice', null);
     }
+  }
+
+  async clearCurrentDevice() {
+    console.log('clear device');
+    Vue.set(this, 'currentDevice', null);
+    this.emit('currentDevice', null);
   }
 
   async writeBuff(buff) {
@@ -227,6 +238,11 @@ class WebSocketSerial extends BaseSerial {
       console.log('websocket-to-serial: connected');
     } catch (err) {
       console.log('websocket-to-serial: connection failed', err);
+      // Pop an error dialog.  Is there a cleaner way to do this?
+      // Maybe show connection statusi (connected/not connected/connecting) in footer bar?
+      alert('Failed to connect to device.');
+      // show 'SELECT DEVICE PORT'
+      this.clearCurrentDevice();
     }
   }
 


### PR DESCRIPTION
Adds status of the connection in the status bar for the currently selected device (disconnected -> connecting -> connected). When connection attempt fails it switches the status to disconnected, but keeps the device selected (to avoid ambiguity between "disconnected" states when no device is yet selected vs. connection failure).

Menu has two additional options when device is selected:
- Reconnect (recycles the connections)
- Reset (drops currently selected device)